### PR TITLE
chore: update deps version for node 20 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   "dependencies": {
     "@types/app-root-path": "^1.2.4",
     "@types/is-image": "^3.0.0",
-    "@types/sharp": "^0.23.1",
     "app-root-path": "^3.0.0",
     "is-image": "^3.0.0",
     "path": "^0.12.7",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "author": "iberatkaya",
   "license": "ISC",
   "devDependencies": {
-    "typescript": "^3.7.4"
+    "typescript": "^5.6.3"
   },
   "repository": {
     "type": "git",
@@ -34,6 +34,6 @@
     "app-root-path": "^3.0.0",
     "is-image": "^3.0.0",
     "path": "^0.12.7",
-    "sharp": "^0.23.4"
+    "sharp": "^0.33.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
     "Data Augmentation"
   ],
   "dependencies": {
-    "@types/app-root-path": "^1.2.4",
+    "@types/app-root-path": "^1.2.8",
     "@types/is-image": "^3.0.0",
-    "app-root-path": "^3.0.0",
+    "app-root-path": "^3.1.0",
     "is-image": "^3.0.0",
     "path": "^0.12.7",
     "sharp": "^0.33.5"


### PR DESCRIPTION
The original version of sharp and typescript no longer work as of now (I'm using node 20)